### PR TITLE
Remove Travis CI

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -9,4 +9,4 @@ jobs:
       - uses: docker/build-push-action@v1
         with:
           repository: arunderwood/bsnstatus
-          push: false
+          push: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-services:
-  - docker
-
-script:
-  - docker build .

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,6 @@
 # BSNstatus
 
 [![Docker Automated build](https://img.shields.io/docker/automated/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/arunderwood/bsnstatus/)
-[![Build Status](https://travis-ci.org/arunderwood/BSNstatus.svg?branch=master)](https://travis-ci.org/arunderwood/BSNstatus)
 
 A responsive webapp that organizes site bookmarks and other useful data into a grid of cards
 


### PR DESCRIPTION
Using Github Actions now, remove failing Travis CI build.