### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-assets.yaml
+++ b/.github/workflows/build-assets.yaml
@@ -1,4 +1,6 @@
 name: Build Assets
+permissions:
+  contents: read
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/arunderwood/BSNstatus/security/code-scanning/24](https://github.com/arunderwood/BSNstatus/security/code-scanning/24)

To address this issue, we should explicitly specify the minimum permissions required for this workflow. Since the workflow only performs build operations and does not push code or create releases, the least privilege needed is read-only access to repository contents. This can be accomplished by adding `permissions: contents: read` at the root of the workflow (just after the `name` and before `on`), which will apply to all jobs by default. No further changes are required unless individual jobs need elevated permissions (which they do not, as per the current snippet). This change does not alter existing functionality and simply tightens the security posture.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
